### PR TITLE
Fix Memory Leak

### DIFF
--- a/src/modules/emotion/gstreamer/emotion_gstreamer.c
+++ b/src/modules/emotion/gstreamer/emotion_gstreamer.c
@@ -1853,6 +1853,8 @@ _emotion_gstreamer_video_pipeline_parse(Emotion_Gstreamer_Video *ev,
         gst_caps_unref(caps);
      unref_pad_v:
         gst_object_unref(pad);
+     if(str)
+	g_free(str);
      }
 
    /* Audio streams */


### PR DESCRIPTION
GStreamer API gst_caps_to_string returns a newly allocated string that must be freed by the caller after use with g_free().
Ref:
1) https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer/html/GstCaps.html#gst-caps-to-string
2) https://developer.gnome.org/glib/2.28/glib-Strings.html#g-string-free 
gst_caps_to_string returns g_string_free with free_segment argument set to FALSE:
gchar *
gst_caps_to_string (const GstCaps * caps)
{
	...
	...
	return g_string_free (s, FALSE);
}